### PR TITLE
Use multistage build to skip libpostal build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,24 @@
-FROM pelias/libpostal_baseimage
+# build the libpostal-server binary separately
+FROM pelias/libpostal_baseimage as builder
 
 # install go
 RUN curl https://dl.google.com/go/go1.11.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH="$PATH:/usr/local/go/bin"
-ENV PORT 4400
 
 # bring in and build project go code
 WORKDIR /code/go-whosonfirst-libpostal
 RUN git clone https://github.com/whosonfirst/go-whosonfirst-libpostal.git .
 RUN make bin
 
+# start of main image
+FROM pelias/libpostal_baseimage
+
+COPY --from=builder /code/go-whosonfirst-libpostal/bin/wof-libpostal-server /bin/
+
 USER pelias
+
+ENV PORT 4400
 
 # set entrypoint to executable, ensuring the host is set so network requests will work
 # additional parameters can be passed on the command line
-ENTRYPOINT [ "./bin/wof-libpostal-server", "-host", "0.0.0.0", "-port", "4400" ]
+ENTRYPOINT [ "/bin/wof-libpostal-server", "-host", "0.0.0.0", "-port", "4400" ]


### PR DESCRIPTION
After https://github.com/pelias/docker-baseimage/pull/23, we will no longer have a compiler toolchain in our Docker baseimage. However, due to the way Docker images work and build upon each other, the biggest wins come from ensuring we don't have a compiler toolchain _anywhere_ in our images.

If you think about it, even a single image having a compiler toolchain is the same as the baseimage having it, at least when comparing the total size of all our images.

Thankfully, with multistage builds we can easily remove both the C++ compiler toolchain and Golang buildtime dependencies in the libpostal service, similar to https://github.com/pelias/polylines/pull/263.

This alone drops the total image size for the libpostal-service from 3.2GB to 2.8GB. Further improvements are possible in the libpostal baseimage in https://github.com/pelias/docker-libpostal_baseimage/pull/5.