### PR TITLE
Fix dependencies for wof libpostal-service build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ FROM pelias/libpostal_baseimage
 
 COPY --from=builder /code/go-whosonfirst-libpostal/bin/wof-libpostal-server /bin/
 
+RUN ldconfig
+
 USER pelias
 
 ENV PORT 4400

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # build the libpostal-server binary separately
 FROM pelias/libpostal_baseimage as builder
 
+RUN apt-get update && apt-get install -y make pkg-config
+
 # install go
 RUN curl https://dl.google.com/go/go1.11.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH="$PATH:/usr/local/go/bin"


### PR DESCRIPTION
Quick follow up to https://github.com/pelias/libpostal-service/pull/4:

The `go-whosonfirst-libpostal` build process requires `automake`, which is no longer in our baseimage!

Also, `ldconfig` needs to be run in the _final_ image, so that the libpostal shared library can be found.