### PR TITLE
Add build-essential apt package to builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # build the libpostal-server binary separately
 FROM pelias/libpostal_baseimage as builder
 
-RUN apt-get update && apt-get install -y make pkg-config
+RUN apt-get update && apt-get install -y make pkg-config build-essential
 
 # install go
 RUN curl https://dl.google.com/go/go1.11.linux-amd64.tar.gz | tar -C /usr/local -xz


### PR DESCRIPTION
As in https://github.com/pelias/docker-libpostal_baseimage/pull/11, Ubuntu 22 has some slightly differing package install semantics where we need to install the `build-essential` package to get `make` and all the other tools needed to compile against libpostal.

This Dockerfile uses a builder image to do all the compiling, and then the compiled results are moved to a new, slim, Docker image, so this change doesn't affect the final image much.

It's just needed to keep everything working for Ubuntu 22

https://github.com/pelias/pelias/issues/951