### PR TITLE
dockerfile: correctly select Go architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM pelias/libpostal_baseimage as builder
 RUN apt-get update && apt-get install -y make pkg-config build-essential
 
 # install go
-RUN curl https://dl.google.com/go/go1.11.linux-amd64.tar.gz | tar -C /usr/local -xz
+ARG TARGETPLATFORM
+RUN curl "https://dl.google.com/go/go1.11.linux-${TARGETPLATFORM##*/}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="$PATH:/usr/local/go/bin"
 
 # bring in and build project go code


### PR DESCRIPTION
this PR detects the target architecture and selects the correct Golang download accordingly.

> note: the `TARGETPLATFORM` is something like `linux/arm64` and the `${TARGETPLATFORM##*/}` command selects everything after the last slash.