### PR TITLE
docker: use TARGETARCH instead of TARGETPLATFORM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM pelias/libpostal_baseimage as builder
 RUN apt-get update && apt-get install -y make pkg-config build-essential
 
 # install go
-ARG TARGETPLATFORM
-RUN curl "https://dl.google.com/go/go1.11.linux-${TARGETPLATFORM##*/}.tar.gz" | tar -C /usr/local -xz
+ARG TARGETARCH
+RUN curl "https://dl.google.com/go/go1.11.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="$PATH:/usr/local/go/bin"
 
 # bring in and build project go code


### PR DESCRIPTION
following on from https://github.com/pelias/libpostal-service/pull/11 this method is a bit cleaner.