### PR TITLE
CI cleanup and new Docker baseimage

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,7 +4,7 @@ jobs:
   build-docker-images:
     runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build Docker images
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 on: push
 jobs:
   build-docker-images:
-    runs-on: ${{ vars.UBUNTU_VERSION }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker images


### PR DESCRIPTION
This PR includes a bunch of commits made by a script that standardizes as much as possible our CI config across all repositories.

Any Github Actions that were out of date or used old Node.js versions (checkout and setup-node @v2) are updated.

Also, the CI OS version is now hardcoded to ubuntu-22.04. We fooled around with an organization wide CI variable to configure that, but it broke CI in forks and doesn't really help us much, so it's now undone.

If there are any other differences in Github Actions Workflow files, they are also now removed by using a standard template.

Finally, because this repository has a Dockerfile and we just updated the baseimage to Node.js 18 in https://github.com/pelias/docker-baseimage/pull/29, there is an empty commit to trigger a new major version release.

Connects https://github.com/pelias/pelias/issues/950
Connects https://github.com/pelias/pelias/issues/951